### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,53 @@
+# Use the official ROS Humble perception image as the base
+FROM ros:humble-perception
+
+# Arguments for user configuration
+ARG USERNAME=pi
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Set environment variables
+ENV SHELL /bin/bash
+
+# Update system (not useful)
+# RUN apt-get update && apt-get upgrade -y
+
+# Install dependencies required for building packages
+RUN apt-get update && apt-get install -y \
+    sudo \
+    python3-pip \
+    openssh-server \
+    net-tools \
+    nano \
+    vim \
+    apt-utils \
+    ufw \
+    iputils-ping \
+    software-properties-common \ 
+    ros-humble-teleop-twist-keyboard \
+    # Intel GPU drivers
+    libgl1-mesa-glx \
+    libgl1-mesa-dri 
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+RUN echo $USERNAME:$USERNAME | chpasswd
+
+# Source the ROS setup.bash file.
+RUN echo "source /opt/ros/humble/setup.bash" >> /home/$USERNAME/.bashrc
+# Enable SSH
+RUN echo "sudo service ssh restart > /dev/null" >> /home/$USERNAME/.bashrc
+
+# [Optional] Set the default user. Omit if you want to keep the default as root.
+USER $USERNAME
+CMD ["service ssh restart"]
+
+# Set the entrypoint to bash
+ENTRYPOINT ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+    "name": "ROS 2 Development Container",
+    "privileged": true,
+    "remoteUser": "pi",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+        "USERNAME": "pi"
+      }
+    },
+    "workspaceFolder": "/home/pi/geicar",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/pi/geicar/,type=bind",
+    "customizations": {
+      "vscode": {
+        "extensions":[
+          "ms-vscode.cpptools",
+          "ms-vscode.cpptools-themes",
+          "twxs.cmake",
+          "donjayamanne.python-extension-pack",
+          "eamodio.gitlens",
+          "ms-iot.vscode-ros",
+          "ms-python.python",
+          "smilerobotics.urdf"
+        ],
+        "settings": {
+          "terminal.integrated.profiles.linux": {
+              "bash (Host)": {
+                  "path": "bash"
+              }
+          },
+          "terminal.integrated.defaultProfile.linux": "bash"
+        }
+      }
+    },
+    "containerEnv": {
+      "DISPLAY": "unix:0",
+      "LIBGL_ALWAYS_SOFTWARE": "1", // Needed for software rendering of opengl
+      "ROS_AUTOMATIC_DISCOVERY_RANGE": "LOCALHOST",
+      "ROS_DOMAIN_ID": "1"
+    },
+    "runArgs": [
+      "-p3000:3000",
+      "-p2222:22",
+      "-p9090:9090",
+      "-e", "DISPLAY=${env:DISPLAY}",
+      "--network=host",
+      "--name=geicar",
+      "-v=/dev:/dev",
+      // "--runtime=nvidia", // NVIDIA GPU support
+      "--device=/dev/dri:/dev/dri" // Intel GPU support
+    ],
+    "mounts": [
+      //"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+      "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached"
+    ],
+    "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
+    "postStartCommand": "sudo service ssh restart"
+  }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo apt update && \
+sudo apt install ros-humble-rviz2 -y && \
+cd raspberryPI3/ros2_ws && \
+colcon build --packages-select interfaces && \
+colcon build --packages-skip interfaces && \
+sudo chown -R $(whoami) /home/pi/geicar

--- a/general/dev_container.md
+++ b/general/dev_container.md
@@ -1,0 +1,22 @@
+# This file describes how to use the dev container
+
+This section explains how to use it using VS Code, other IDEs might use it differently.
+
+## Prerequisites
+
+- [VS Code](https://code.visualstudio.com/)
+- Docker ([on Windows](https://docs.docker.com/desktop/install/windows-install/) / [on Linux](https://docs.docker.com/desktop/install/linux/))
+- Install VS Code extensions: Remote Explorer, Docker, Dev Container (all from Microsoft)
+
+## First time
+
+1. Open this project `geicar` in VS Code
+2. Go the the Remote Explorer menu on the left
+3. Click on the Plus button to add a New Dev Container
+4. Select `Open Current folder in Container`
+5. The container opens and you can use bash in VS Code
+
+## Other times
+
+1. Click on the green/blue button at the very left bottom corner
+2. `Reopen folder in Container`


### PR DESCRIPTION
This adds a Development container configuration for our project. 

Basically, here are the things done:
- It creates a Docker container with ROS2 installed
- It loads a configuration files when running the container
- When it is loaded for the first time (or modified), it tries to build with `colcon` our ROS2 nodes
- Documentation so that you know how to use these files

Feel free to ask questions about it if you do not understand why or how it works.