### PR TITLE
feat-34: Add tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
         colcon build --packages-select interfaces --cmake-args -Wno-dev
         colcon build --packages-skip interfaces --cmake-args -Wno-dev
 
+    - name: Test with colcon
+      run: |
+        source /opt/ros/humble/setup.bash
+        colcon test
+
     - name: Set latest commit status as ${{ job.status }}
       uses: myrotvorets/set-commit-status-action@master
       if: always()

--- a/raspberryPI3/ros2_ws/src/can/package.xml
+++ b/raspberryPI3/ros2_ws/src/can/package.xml
@@ -9,8 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/car_control/package.xml
+++ b/raspberryPI3/ros2_ws/src/car_control/package.xml
@@ -14,8 +14,6 @@
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/carla_msgs/package.xml
+++ b/raspberryPI3/ros2_ws/src/carla_msgs/package.xml
@@ -18,8 +18,6 @@
 
   <member_of_group>rosidl_interface_packages</member_of_group>
   
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/geicar_start/package.xml
+++ b/raspberryPI3/ros2_ws/src/geicar_start/package.xml
@@ -9,8 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   
   <exec_depend>joystick_ros2</exec_depend>

--- a/raspberryPI3/ros2_ws/src/interfaces/package.xml
+++ b/raspberryPI3/ros2_ws/src/interfaces/package.xml
@@ -18,8 +18,6 @@
 
   <member_of_group>rosidl_interface_packages</member_of_group>
   
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/joystick/package.xml
+++ b/raspberryPI3/ros2_ws/src/joystick/package.xml
@@ -15,8 +15,6 @@
   <depend>sensor_msgs</depend>
   <depend>interfaces</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/simulation/package.xml
+++ b/raspberryPI3/ros2_ws/src/simulation/package.xml
@@ -13,8 +13,6 @@
   <depend>interfaces</depend>
   <depend>carla_msgs</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/raspberryPI3/ros2_ws/src/system_check/package.xml
+++ b/raspberryPI3/ros2_ws/src/system_check/package.xml
@@ -13,8 +13,6 @@
   <depend>interfaces</depend>
   <depend>sensor_msgs</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Previously `colcon test` command exited with errors because there were many lint errors. As we are using several languages, we need multiple tools to autoformat the code. There are not such tools by default with ROS2. 

I tried to fix lint errors in Python with black without success. Blake and ROS2 linters have different rules. I did not want to spend too much time on it as it is not our priority and the most important is to have automatic unit/integration tests, not autoformat.