### PR TITLE
bug-32: Add automatic time/date synchronization

### DIFF
--- a/raspberryPI3/configuration_files/time_update.sh
+++ b/raspberryPI3/configuration_files/time_update.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+date -s "$(curl http://s3.amazonaws.com -v 2>&1 | \
+	grep "Date: " | awk '{ print $3 " " $5 " " $4 " " $7 " " $6 " GMT"}')"

--- a/raspberryPI3/initial_configuration.md
+++ b/raspberryPI3/initial_configuration.md
@@ -246,3 +246,11 @@ echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 echo "source ~/ros2_ws/install/local_setup.bash" >> ~/.bashrc
 echo "export ROS_DOMAIN_ID=XX" >> ~/.bashrc
 ```
+
+### Automatic time/date synchronization
+
+1. Switch to root user `su`
+2. Copy the `time_update.sh` file to your root directory (`/root/time_update.sh`)
+3. Add the executable right to the file: `chmod +x time_update.sh`
+4. Add a cronjob with: `crontab -e` (be sure to be connected as root or do `sudo` otherwise)
+5. In the file opend by the previous command, add the following: `@reboot sh $HOME/time_update.sh`


### PR DESCRIPTION
The car did not synchronized time automatically. It led to many network problems.
Using usual tools does not work to automatically sync. So I made this trick and that works.