### PR TITLE
feat-50: Add parking slots to the website map

### DIFF
--- a/website/js/map.js
+++ b/website/js/map.js
@@ -2,7 +2,7 @@
 var map = L.map('map').setView([43.5705915, 1.4663547, 84], 19);
 
 // Add Google Maps tiles to the map (best one found to see parking lots with a good zooming level)
-var googleSat = L.tileLayer('http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+var googleSat = L.tileLayer('https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
     maxZoom: 22,
     subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
 }).addTo(map);
@@ -22,3 +22,80 @@ legend.onAdd = function (map) {
     return div;
 };
 legend.addTo(map);
+
+
+var parking_nodes = [];
+var parking_ways = [];
+
+function storeParkingData(data) {
+    data.elements.forEach(element => {
+        if (element.type === "node") {
+            parking_nodes.push(element);
+        } else if (element.type === "way") {
+            parking_ways.push(element);
+        }
+    });
+}
+
+// Function to fetch parking data from Overpass API
+function fetchParkingData() {
+    var overpassQuery = `
+        [out:json];
+        (
+          node["amenity"="parking_space"](around:100,43.5705915,1.4663547);
+          way["amenity"="parking_space"](around:100,43.5705915,1.4663547);
+          relation["amenity"="parking_space"](around:100,43.5705915,1.4663547);
+        );
+        out body;
+        >;
+        out skel qt;
+    `;
+
+    var url = "https://overpass-api.de/api/interpreter?data=" + encodeURIComponent(overpassQuery);
+
+    fetch(url)
+        .then(response => response.json())
+        .then(data => {
+            storeParkingData(data);
+            addParkingToMap();
+        })
+        .catch(error => console.error('Error fetching parking data:', error));
+}
+
+var parking_spaces_polygons = [];
+popup = new L.Popup();
+function addParkingToMap() {
+    var parkingLayer = L.geoJSON(null, {
+        style: function (feature) {
+            return { color: "blue" }; // Styling for parking areas
+        },
+        pointToLayer: function (feature, latlng) {
+            return L.marker(latlng, { icon: L.icon({ iconUrl: 'parking-icon.png', iconSize: [20, 20] }) });
+        }
+    });
+    parking_ways.forEach(element => {
+        // Get all nodes of the ways
+        // Get their coordinates
+        // Make a polygone
+        var nodes_id = element.nodes;
+        var coordinates = nodes_id
+            .map(id => parking_nodes.find(node => node.id == id)) // Find the node by ID
+            .filter(node => node) // Ensure no `undefined` values are included
+            .map(node => [node.lat, node.lon]);
+        let poly = L.polygon(coordinates)
+        poly.on("click", function (e) {
+            var bounds = poly.getBounds();
+            var popupContent = "FREE";
+            popup.setLatLng(bounds.getCenter());
+            popup.setContent(popupContent);
+            map.openPopup(popup);
+        });
+        parking_spaces_polygons.push(coordinates);
+        parkingLayer.addLayer(poly);
+    })
+    parkingLayer.addTo(map);
+}
+
+
+// Fetch parking data
+fetchParkingData();


### PR DESCRIPTION
It only loads parking slots from OpenStreetMaps. It means that we need to add parking slots in OpenStreetMaps to see them on our map.

**Preview:**
![image](https://github.com/user-attachments/assets/534d2163-3e4f-4e48-aecd-444377506a26)

The reason why parking slots are not well aligned is because there's a small shift between Google Maps Satellite images (here) and OpenStreetMaps images (used to create parking slots).