### PR TITLE
Change frame_id value of /imu_data to "base_link"

### DIFF
--- a/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
+++ b/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
@@ -219,7 +219,7 @@ private:
                 auto navsat_msg = sensor_msgs::msg::NavSatFix();
                 bool use_gps_shift_fix = this->get_parameter("gps_shift_fix").as_bool();
                 navsat_msg.header.stamp = this->get_clock()->now();
-                navsat_msg.header.frame_id = "gps";
+                navsat_msg.header.frame_id = "base_link";
 
                 navsat_msg.latitude = latitude;
                 navsat_msg.longitude = longitude;

--- a/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
+++ b/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
@@ -45,6 +45,12 @@ def generate_launch_description():
         parameters=[os.path.join(config_dir, 'imu_filter.yaml')],
         emulate_tty=True
     )
+    
+    imu_frame_id_modifier_node = Node(
+        package="imu_filter_madgwick",
+        executable="imu_frame_id_modifier_node",
+        emulate_tty=True
+    )
 
     system_check_node = Node(
         package="system_check",
@@ -70,6 +76,7 @@ def generate_launch_description():
     ld.add_action(can_tx_node)
     ld.add_action(car_control_node)
     ld.add_action(imu_filter_madgwick_node)
+    ld.add_action(imu_frame_id_modifier_node)
     ld.add_action(system_check_node)
     ld.add_action(rosbridge_server_node)
     ld.add_action(obstacles_detection_node)

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/CMakeLists.txt
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/CMakeLists.txt
@@ -34,6 +34,7 @@ ament_target_dependencies(imu_filter_madgwick
   tf2_geometry_msgs
   tf2_ros
 )
+
 rclcpp_components_register_nodes(imu_filter_madgwick "ImuFilterMadgwickRos")
 target_compile_definitions(imu_filter_madgwick
   PRIVATE "IMU_FILTER_MADGWICK_CPP_BUILDING_DLL")
@@ -42,6 +43,15 @@ add_executable(imu_filter_madgwick_node src/imu_filter_node.cpp)
 target_link_libraries(imu_filter_madgwick_node imu_filter_madgwick)
 ament_target_dependencies(imu_filter_madgwick_node
   rclcpp)
+
+# Add the imu_frame_id_modifier_node target
+add_executable(imu_frame_id_modifier_node src/imu_frame_id_modifier.cpp)
+
+# Link dependencies to imu_frame_id_modifier_node
+ament_target_dependencies(imu_frame_id_modifier_node
+  rclcpp
+  sensor_msgs
+)
 
 install(TARGETS
   imu_filter_madgwick
@@ -58,6 +68,11 @@ install(
 
 install(TARGETS
   imu_filter_madgwick_node
+  DESTINATION lib/${PROJECT_NAME})
+
+# Install imu_frame_id_modifier_node executable
+install(TARGETS
+  imu_frame_id_modifier_node
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/config/imu_filter.yaml
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/config/imu_filter.yaml
@@ -14,3 +14,5 @@ imu_filter:
     mag_bias_y: 0.0
     mag_bias_z: 0.0
     orientation_stddev: 0.0
+
+    imu_frame : "base_link"

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -488,7 +488,7 @@ void ImuFilterMadgwickRos::publishFilteredMsg(
         tf2::Matrix3x3(tf2::Quaternion(q1, q2, q3, q0))
             .getRPY(rpy.vector.x, rpy.vector.y, rpy.vector.z);
 
-        rpy.header = imu_msg_raw->header;
+        rpy.header = imu_msg_raw->header;  //A PEUT-ÊTRE CHANGER
         rpy_filtered_debug_publisher_->publish(rpy);
     }
 }

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -234,9 +234,6 @@ void ImuFilterMadgwickRos::imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw)
 
     rclcpp::Time time = imu_msg_raw->header.stamp;
 
-    //************************************************************************************ */
-    //imu_frame_ = imu_msg_raw->header.frame_id;
-
     if (!initialized_ || stateless_)
     {
         geometry_msgs::msg::Quaternion init_q;
@@ -299,9 +296,6 @@ void ImuFilterMadgwickRos::imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw,
     const geometry_msgs::msg::Vector3 &mag_fld = mag_msg->magnetic_field;
 
     rclcpp::Time time = imu_msg_raw->header.stamp;
-
-    //***************************************************************************** */
-    //imu_frame_ = imu_msg_raw->header.frame_id;
 
     /*** Compensate for hard iron ***/
     geometry_msgs::msg::Vector3 mag_compensated;
@@ -488,7 +482,7 @@ void ImuFilterMadgwickRos::publishFilteredMsg(
         tf2::Matrix3x3(tf2::Quaternion(q1, q2, q3, q0))
             .getRPY(rpy.vector.x, rpy.vector.y, rpy.vector.z);
 
-        rpy.header = imu_msg_raw->header;  //A PEUT-ÊTRE CHANGER
+        rpy.header = imu_msg_raw->header;  
         rpy_filtered_debug_publisher_->publish(rpy);
     }
 }

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_filter_ros.cpp
@@ -59,6 +59,9 @@ ImuFilterMadgwickRos::ImuFilterMadgwickRos(const rclcpp::NodeOptions &options)
     declare_parameter("publish_debug_topics", false);
     get_parameter("publish_debug_topics", publish_debug_topics_);
 
+    declare_parameter("imu_frame", "base_link");
+    get_parameter("imu_frame", imu_frame_);
+
     double yaw_offset = 0.0;
     declare_parameter("yaw_offset", 0.0);
     get_parameter("yaw_offset", yaw_offset);
@@ -230,7 +233,9 @@ void ImuFilterMadgwickRos::imuCallback(ImuMsg::ConstSharedPtr imu_msg_raw)
     rclcpp::Clock steady_clock(RCL_STEADY_TIME);  // for throttle logger message
 
     rclcpp::Time time = imu_msg_raw->header.stamp;
-    imu_frame_ = imu_msg_raw->header.frame_id;
+
+    //************************************************************************************ */
+    //imu_frame_ = imu_msg_raw->header.frame_id;
 
     if (!initialized_ || stateless_)
     {
@@ -294,7 +299,9 @@ void ImuFilterMadgwickRos::imuMagCallback(ImuMsg::ConstSharedPtr imu_msg_raw,
     const geometry_msgs::msg::Vector3 &mag_fld = mag_msg->magnetic_field;
 
     rclcpp::Time time = imu_msg_raw->header.stamp;
-    imu_frame_ = imu_msg_raw->header.frame_id;
+
+    //***************************************************************************** */
+    //imu_frame_ = imu_msg_raw->header.frame_id;
 
     /*** Compensate for hard iron ***/
     geometry_msgs::msg::Vector3 mag_compensated;
@@ -461,6 +468,8 @@ void ImuFilterMadgwickRos::publishFilteredMsg(
     imu_msg.orientation_covariance[6] = 0.0;
     imu_msg.orientation_covariance[7] = 0.0;
     imu_msg.orientation_covariance[8] = orientation_variance_;
+
+    imu_msg.header.frame_id= imu_frame_;
 
     if (remove_gravity_vector_)
     {

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
@@ -1,7 +1,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 
-// Class definition for the IMU Frame ID Modifier Node
 class ImuFrameIdModifier : public rclcpp::Node {
 public:
     ImuFrameIdModifier() : Node("imu_frame_id_modifier") {
@@ -10,39 +9,30 @@ public:
             "/imu/data", 10,
             std::bind(&ImuFrameIdModifier::imu_callback, this, std::placeholders::_1));
 
-        // Publisher for the modified topic (/imu/modified_data)
+        // Publisher for the modified topic (/imu/modified_frame_id)
         publisher_ = this->create_publisher<sensor_msgs::msg::Imu>("/imu/modified_frame_id", 10);
     }
 
 private:
     // Callback function for the subscription
     void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg) {
-        // Create a copy of the received message
         auto modified_msg = *msg;
 
-        // Modify the frame_id of the header
-        modified_msg.header.frame_id = "base_link"; // Replace with desired frame_id
+        modified_msg.header.frame_id = "base_link"; 
 
-        // Publish the modified message
         publisher_->publish(modified_msg);
     }
 
-    // Subscription object
     rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr subscription_;
 
-    // Publisher object
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr publisher_;
 };
 
-// Main function
 int main(int argc, char **argv) {
-    // Initialize the ROS 2 system
     rclcpp::init(argc, argv);
 
-    // Spin the node (process callbacks)
     rclcpp::spin(std::make_shared<ImuFrameIdModifier>());
 
-    // Shutdown the ROS 2 system
     rclcpp::shutdown();
     return 0;
 }

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
@@ -11,7 +11,7 @@ public:
             std::bind(&ImuFrameIdModifier::imu_callback, this, std::placeholders::_1));
 
         // Publisher for the modified topic (/imu/modified_data)
-        publisher_ = this->create_publisher<sensor_msgs::msg::Imu>("/imu/modified_data", 10);
+        publisher_ = this->create_publisher<sensor_msgs::msg::Imu>("/imu/modified_frame_id", 10);
     }
 
 private:

--- a/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
+++ b/raspberryPI3/ros2_ws/src/imu_tools/imu_filter_madgwick/src/imu_frame_id_modifier.cpp
@@ -1,0 +1,48 @@
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+
+// Class definition for the IMU Frame ID Modifier Node
+class ImuFrameIdModifier : public rclcpp::Node {
+public:
+    ImuFrameIdModifier() : Node("imu_frame_id_modifier") {
+        // Subscription to the input topic (/imu/data)
+        subscription_ = this->create_subscription<sensor_msgs::msg::Imu>(
+            "/imu/data", 10,
+            std::bind(&ImuFrameIdModifier::imu_callback, this, std::placeholders::_1));
+
+        // Publisher for the modified topic (/imu/modified_data)
+        publisher_ = this->create_publisher<sensor_msgs::msg::Imu>("/imu/modified_data", 10);
+    }
+
+private:
+    // Callback function for the subscription
+    void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg) {
+        // Create a copy of the received message
+        auto modified_msg = *msg;
+
+        // Modify the frame_id of the header
+        modified_msg.header.frame_id = "base_link"; // Replace with desired frame_id
+
+        // Publish the modified message
+        publisher_->publish(modified_msg);
+    }
+
+    // Subscription object
+    rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr subscription_;
+
+    // Publisher object
+    rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr publisher_;
+};
+
+// Main function
+int main(int argc, char **argv) {
+    // Initialize the ROS 2 system
+    rclcpp::init(argc, argv);
+
+    // Spin the node (process callbacks)
+    rclcpp::spin(std::make_shared<ImuFrameIdModifier>());
+
+    // Shutdown the ROS 2 system
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
To use the robot_localization package, we need to know the frame_id of each sensor. 
The default value of the frame_id of /imu/data is ' ', we need it to be "base_link". The topic /imu/data is published after a filter is applied on the topic /imu/data_raw. 
So, I changed the value of the frame_id by inserting a new ros param in imu_filter_madgwick to use it in imu_filter_ros.cpp. 

At first, this was not working so I created a new node imu_frame_id_modifier to publish a new topic name /imu/modified_frame_id witch copy the /imu/data topic and change the frame_id to "base_link". 

Now, both of the solutions are working (and idk why they did not work at first) so I prefer to keep both just in case.