### PR TITLE
Feature/81/integrate gps in kalman filter ronan

### DIFF
--- a/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
+++ b/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
@@ -400,6 +400,10 @@ private:
                 imu_raw_msg.angular_velocity.z = ang_vel_z * pow(1.7453,-5);    //Conversion to [rad/s]
 
                 imu_raw_msg.header.stamp = rclcpp::Clock().now();
+
+                imu_raw_msg.orientation_covariance={1e-3, 0, 0, 0, 1e-3, 0, 0, 0, 1e-3};
+                imu_raw_msg.linear_acceleration_covariance={1e-4, 0, 0, 0, 1e-4, 0, 0, 0, 1e-4};
+                imu_raw_msg.angular_velocity_covariance={1e-2, 0, 0, 0, 1e-2, 0, 0, 0, 1e-2};
                 
                 publisher_imu_raw_->publish(imu_raw_msg);
 

--- a/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
+++ b/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
@@ -143,7 +143,12 @@ private:
                 double v = (v_left + v_right) / 2.0;
 
                 // Compute angular velocity using the steering angle
-                double omega = v * std::tan(motorsFeedbackMsg.steering_angle*ANGLE_MAX) / WHEEL_BASE;
+                double fixed_steering_angle = motorsFeedbackMsg.steering_angle;
+                if (fixed_steering_angle > -0.1 && fixed_steering_angle < 0.1) {
+                    fixed_steering_angle = 0.0;
+                } 
+                
+                double omega = v * std::tan(fixed_steering_angle*ANGLE_MAX) / WHEEL_BASE;
 
                 // Update pose using kinematic model
                 odom_x += v * std::cos(odom_theta) * dt;

--- a/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
+++ b/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
@@ -269,7 +269,7 @@ private:
                 auto navsat_msg = sensor_msgs::msg::NavSatFix();
                 bool use_gps_shift_fix = this->get_parameter("gps_shift_fix").as_bool();
                 navsat_msg.header.stamp = this->get_clock()->now();
-                navsat_msg.header.frame_id = "map";
+                navsat_msg.header.frame_id = "base_link";
 
                 navsat_msg.latitude = latitude;
                 navsat_msg.longitude = longitude;

--- a/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
+++ b/raspberryPI3/ros2_ws/src/can/src/can_rx_node.cpp
@@ -269,7 +269,7 @@ private:
                 auto navsat_msg = sensor_msgs::msg::NavSatFix();
                 bool use_gps_shift_fix = this->get_parameter("gps_shift_fix").as_bool();
                 navsat_msg.header.stamp = this->get_clock()->now();
-                navsat_msg.header.frame_id = "base_link";
+                navsat_msg.header.frame_id = "map";
 
                 navsat_msg.latitude = latitude;
                 navsat_msg.longitude = longitude;

--- a/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
+++ b/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
@@ -7,21 +7,21 @@ ekf_filter_node_odom:
     two_d_mode: true
 
     # Specify the sensor data sources (topics)
-    odom0: "/odom/encoder"
-    imu0: "/imu/modified_frame_id"
+    odom0: "/odom/encoder_flip"
+    #imu0: "/imu/modified_frame_id"
 
     # Delay in sensor data processing
     sensor_timeout: 0.1
 
-    imu0_config: [false, false, false,
-                false, false, true,
-                false, false, false,
-                false, false, true,
-                true, false, false]
+    # imu0_config: [false, false, false,
+    #             false, false, true,
+    #             false, false, false,
+    #             false, false, true,
+    #             true, false, false]
 
     odom0_config: [true, true, false,
                 false, false, true,
-                true, false, false,
+                true, true, false,
                 false, false, true,
                 false, false, false]
 
@@ -38,39 +38,86 @@ ekf_filter_node_map:
     # Frequency of the EKF updates
     frequency: 20.0
     two_d_mode: true
+    # Delay in sensor data processing
+    sensor_timeout: 0.15
+    print_diagnostics: false
+    debug: false
 
     # Specify the sensor data sources (topics)
-    odom0: "/odom/encoder"
-    imu0: "/imu/modified_frame_id"
-    odom1: "/odometry/gps"
+    # odom1: "/odom/encoder"
 
+    #imu0: "/imu/modified_frame_id"
 
-    # Delay in sensor data processing
-    sensor_timeout: 0.1
+    odom1: "/odometry/localronan"
 
-    imu0_config: [false, false, false,
+    odom1_config: [true, true, false,
                 false, false, true,
-                false, false, false,
-                false, false, true,
-                true, false, false]
-
-    odom0_config: [true, true, false,
-                false, false, true,
-                true, false, false,
+                true, true, false,
                 false, false, true,
                 false, false, false]
-    
-    odom1_config: [true,  true,  false,
+
+    odom1_differential: true
+    odom1_relative: true
+    odom1_queue_size: 10
+    odom1_nodelay: false
+    odom1_pose_covariance: [1e-3, 0.0, 0.0, 0.0, 0.0, 0.0,
+                            0.0, 1e-3, 0.0, 0.0, 0.0, 0.0,
+                            0.0, 0.0, 2e-1, 0.0, 0.0, 0.0,
+                            0.0, 0.0, 0.0, 2e-1, 0.0, 0.0,
+                            0.0, 0.0, 0.0, 0.0, 1e-3, 0.0,
+                            0.0, 0.0, 0.0, 0.0, 0.0, 1e-4]
+
+
+    odom1_twist_covariance: [1e-2, 0.0, 0.0, 0.0, 0.0, 0.0,
+                              0.0, 1e-2, 0.0, 0.0, 0.0, 0.0,
+                              0.0, 0.0, 1e-1, 0.0, 0.0, 0.0,
+                              0.0, 0.0, 0.0, 1e-1, 0.0, 0.0,
+                              0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                              0.0, 0.0, 0.0, 0.0, 0.0, 1e-4]
+
+
+
+    odom0: "/odometry/gps"
+    odom0_config: [true,  true,  false,
                 false, false, false,
                 false, false, false,
                 false, false, false,
                 false, false, false]
+
+    odom0_differential: false
+    odom0_relative: false
+    odom0_queue_size: 50
+    odom0_nodelay: false
+    odom0_pose_rejection_threshold: 5.0
+
+    odom0_pose_covariance: [1e-2, 0.0, 0.0, 0.0, 0.0, 0.0,
+                            0.0, 1e-2, 0.0, 0.0, 0.0, 0.0,
+                            0.0, 0.0, 1e1, 0.0, 0.0, 0.0,  # Increase trust in x, y position
+                            0.0, 0.0, 0.0, 1e1, 0.0, 0.0,
+                            0.0, 0.0, 0.0, 0.0, 1e3, 0.0,  # Decrease trust in orientation (roll, pitch, yaw)
+                            0.0, 0.0, 0.0, 0.0, 0.0, 1e3]  # Decrease trust in orientation
+
+
+    use_control: false
+
+    # initial_estimate_covariance: [0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
+    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
+    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
+    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
+    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
+    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001]
+
+    #process_noise_covariance: [0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+    # initial_estimate_covariance: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+    #process_noise_covariance: [0.05, 0.05, 0.06, 0.03, 0.03, 0.03, 0.06, 0.025, 0.025, 0.04, 0.01, 0.01, 0.02, 0.01, 0.015]
+    #process_noise_covariance: [0.1, 0.1, 1e-4, 0.01, 0.01, 0.001, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+    #initial_estimate_covariance: [0.1, 0.1, 1e-6, 0.1, 0.1, 1e-6, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
     
     # Frame IDs
     map_frame: "map"
     odom_frame: "odom"
     base_link_frame: "base_link"
-    world_frame : "map"
+    world_frame : "odom"
     
 navsat_transform:
   ros__parameters:

--- a/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
+++ b/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
@@ -34,87 +34,44 @@ ekf_filter_node_odom:
 
 ekf_filter_node_map:
   ros__parameters:
+
+    # Frequency of the EKF updates
     frequency: 30.0
+    two_d_mode: true
+
+    # Specify the sensor data sources (topics)
+    odom0: "/odom/encoder"
+    imu0: "/imu/modified_frame_id"
+    odom1: "/odometry/gps"
+
+
+    # Delay in sensor data processing
     sensor_timeout: 0.1
-    two_d_mode: false
-    transform_time_offset: 0.0
-    transform_timeout: 0.0
-    print_diagnostics: true
-    debug: false
 
-    map_frame: map
-    odom_frame: odom
-    base_link_frame: base_link
-    world_frame: map
-
-    odom0: odom/encoder
-    odom0_config: [false, false, false,
-                  false, false, false,
-                  true,  true,  true,
-                  false, false, true,
-                  false, false, false]
-    odom0_queue_size: 10
-    odom0_nodelay: true
-    odom0_differential: false
-    odom0_relative: false
-
-    odom1: odometry/gps
-    odom1_config: [true,  true,  false,
-                  false, false, false,
-                  false, false, false,
-                  false, false, false,
-                  false, false, false]
-    odom1_queue_size: 10
-    odom1_nodelay: true
-    odom1_differential: false
-    odom1_relative: false
-
-    imu0: imu/modified_frame_id
     imu0_config: [false, false, false,
-                  true,  true,  false,
-                  false, false, false,
-                  true,  true,  true,
-                  true,  true,  true]
-    imu0_nodelay: true
-    imu0_differential: false
-    imu0_relative: false
-    imu0_queue_size: 10
-    imu0_remove_gravitational_acceleration: true
+                false, false, true,
+                false, false, false,
+                false, false, true,
+                true, false, false]
 
-    use_control: false
-
-    process_noise_covariance: [1.0,   0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    1e-3,   0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.3,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.3,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.01,   0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.5,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.5,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.1,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.3,    0.0,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.3,    0.0,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.3,    0.0,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.3,    0.0,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.3,    0.0,
-                              0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.3]
-
-    initial_estimate_covariance: [1.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    1e-9,   0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    1e-9,   0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    1.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    1.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    1.0,    0.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    1.0,     0.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     1.0,     0.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     1.0,     0.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     1.0,    0.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    1.0,    0.0,
-                                  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    1.0]
-
+    odom0_config: [true, true, false,
+                false, false, true,
+                true, false, false,
+                false, false, true,
+                false, false, false]
+    
+    odom1_config: [true,  true,  false,
+                false, false, false,
+                false, false, false,
+                false, false, false,
+                false, false, false]
+    
+    # Frame IDs
+    map_frame: "map"
+    odom_frame: "odom"
+    base_link_frame: "base_link"
+    world_frame : "map"
+    
 navsat_transform:
   ros__parameters:
     frequency: 30.0

--- a/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
+++ b/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
@@ -3,7 +3,7 @@
 ekf_filter_node_odom:
   ros__parameters:
     # Frequency of the EKF updates
-    frequency: 30.0
+    frequency: 20.0
     two_d_mode: true
 
     # Specify the sensor data sources (topics)
@@ -36,7 +36,7 @@ ekf_filter_node_map:
   ros__parameters:
 
     # Frequency of the EKF updates
-    frequency: 30.0
+    frequency: 20.0
     two_d_mode: true
 
     # Specify the sensor data sources (topics)
@@ -74,12 +74,12 @@ ekf_filter_node_map:
     
 navsat_transform:
   ros__parameters:
-    frequency: 30.0
+    frequency: 20.0
     delay: 3.0
     magnetic_declination_radians: 0.0429351  # For lat/long 55.944831, -3.186998
     yaw_offset: 1.570796327  # IMU reads 0 facing magnetic north, not east
-    zero_altitude: false
-    broadcast_utm_transform: true
+    zero_altitude: true
+    broadcast_cartesian_transform: true
     publish_filtered_gps: true
     use_odometry_yaw: false
     wait_for_datum: false

--- a/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
+++ b/raspberryPI3/ros2_ws/src/geicar_start/config/ekf_config.yaml
@@ -7,7 +7,7 @@ ekf_filter_node_odom:
     two_d_mode: true
 
     # Specify the sensor data sources (topics)
-    odom0: "/odom/encoder_flip"
+    odom0: "/odom/encoder"
     #imu0: "/imu/modified_frame_id"
 
     # Delay in sensor data processing
@@ -48,7 +48,7 @@ ekf_filter_node_map:
 
     #imu0: "/imu/modified_frame_id"
 
-    odom1: "/odometry/localronan"
+    odom1: "/odometry/local"
 
     odom1_config: [true, true, false,
                 false, false, true,
@@ -100,19 +100,6 @@ ekf_filter_node_map:
 
     use_control: false
 
-    # initial_estimate_covariance: [0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
-    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
-    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
-    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
-    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001,
-    #                           0.001, 0.001, 0.001, 0.001, 0.001, 0.001]
-
-    #process_noise_covariance: [0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-    # initial_estimate_covariance: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-    #process_noise_covariance: [0.05, 0.05, 0.06, 0.03, 0.03, 0.03, 0.06, 0.025, 0.025, 0.04, 0.01, 0.01, 0.02, 0.01, 0.015]
-    #process_noise_covariance: [0.1, 0.1, 1e-4, 0.01, 0.01, 0.001, 0.05, 0.05, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-    #initial_estimate_covariance: [0.1, 0.1, 1e-6, 0.1, 0.1, 1e-6, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-    
     # Frame IDs
     map_frame: "map"
     odom_frame: "odom"

--- a/raspberryPI3/ros2_ws/src/geicar_start/launch/ekf.launch.py
+++ b/raspberryPI3/ros2_ws/src/geicar_start/launch/ekf.launch.py
@@ -1,0 +1,29 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import os
+from ament_index_python.packages import get_package_share_directory
+
+def generate_launch_description():
+    localization_config_dir = os.path.join(get_package_share_directory('geicar_start'), 'config')
+
+    local_localization_node = Node(
+        package='robot_localization', 
+        executable='ekf_node', 
+        name='ekf_filter_node_odom',
+        output='screen',
+        parameters=[os.path.join(localization_config_dir, 'ekf_config.yaml')],
+        remappings=[('odometry/filtered', 'odometry/localronan')]
+    ) 
+    
+    global_localization_node = Node(
+        package='robot_localization', 
+        executable='ekf_node', 
+        name='ekf_filter_node_map',
+	    output='screen',
+        parameters=[os.path.join(localization_config_dir, 'ekf_config.yaml')],
+        remappings=[('odometry/filtered', 'odometry/globalronan')]
+    )
+    return LaunchDescription([
+        local_localization_node,
+        global_localization_node
+    ])

--- a/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
+++ b/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
@@ -72,7 +72,7 @@ def generate_launch_description():
 
     localization_config_dir = os.path.join(get_package_share_directory('geicar_start'), 'config')
 
-    robot_localization_node = Node(
+    local_localization_node = Node(
         package='robot_localization', 
         executable='ekf_node', 
         name='ekf_filter_node_odom',
@@ -91,8 +91,19 @@ def generate_launch_description():
                     ('gps/fix', 'gps/fix'), 
                     ('gps/filtered', 'gps/filtered'),
                     ('odometry/gps', 'odometry/gps')]           
-    )   
+    )
+        
     
+    global_localization_node = Node(
+        package='robot_localization', 
+        executable='ekf_node', 
+        name='ekf_filter_node_map',
+	    output='screen',
+        parameters=[os.path.join(localization_config_dir, 'ekf_config.yaml')],
+        remappings=[('odometry/filtered', 'odometry/global')]
+    )
+       
+
     mqtt_client_node = Node(
         package="mqtt_client",
         executable="mqtt_client",
@@ -110,7 +121,8 @@ def generate_launch_description():
     ld.add_action(system_check_node)
     ld.add_action(rosbridge_server_node)
     ld.add_action(obstacles_detection_node)
-    ld.add_action(robot_localization_node)
+    ld.add_action(local_localization_node)
     ld.add_action(navsat_transform_node)
+    ld.add_action(global_localization_node)
 
     return ld

--- a/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
+++ b/raspberryPI3/ros2_ws/src/geicar_start/launch/geicar.launch.py
@@ -72,6 +72,32 @@ def generate_launch_description():
 
     localization_config_dir = os.path.join(get_package_share_directory('geicar_start'), 'config')
 
+
+    navsat_transform_node = Node(
+        package='robot_localization',
+        executable='navsat_transform_node',
+        name='navsat_transform_node',
+        output='screen',
+        parameters=[
+            {'use_sim_time': False},
+            {'magnetic_declination_radians': 0.0},
+            {'yaw_offset': 0.0},
+            {'zero_altitude': False},
+            {'base_link_frame': 'base_link'},
+            {'world_frame': 'odom'},
+        ],
+        remappings=[
+            ('/imu', '/imu/modified_frame_id'),
+            ('/gps/fix', '/gps/fix'),
+            ('/odometry/filtered', '/odometry/global'),
+            ('/odometry/gps', '/odometry/gps'),
+        ],
+        arguments=[
+            '--ros-args', '--log-level', 'debug'
+        ]
+    )
+        
+    
     local_localization_node = Node(
         package='robot_localization', 
         executable='ekf_node', 
@@ -80,19 +106,6 @@ def generate_launch_description():
         parameters=[os.path.join(localization_config_dir, 'ekf_config.yaml')],
         remappings=[('odometry/filtered', 'odometry/local')]
     ) 
-
-    navsat_transform_node = Node(
-        package='robot_localization', 
-        executable='navsat_transform_node', 
-        name='navsat_transform',
-        output='screen',
-        parameters=[os.path.join(localization_config_dir, 'ekf_config.yaml')],
-        remappings=[('imu/data', '/imu/modified_frame_id'),
-                    ('gps/fix', 'gps/fix'), 
-                    ('gps/filtered', 'gps/filtered'),
-                    ('odometry/gps', 'odometry/gps')]           
-    )
-        
     
     global_localization_node = Node(
         package='robot_localization', 

--- a/raspberryPI3/ros2_ws/src/geicar_start/launch/navsat.launch.py
+++ b/raspberryPI3/ros2_ws/src/geicar_start/launch/navsat.launch.py
@@ -1,0 +1,30 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    
+    return LaunchDescription([
+        Node(
+            package='robot_localization',
+            executable='navsat_transform_node',
+            name='navsat_transform_node',
+            output='screen',
+            parameters=[
+                {'use_sim_time': False},
+                {'magnetic_declination_radians': 0.0},
+                {'yaw_offset': 0.0},
+                {'zero_altitude': False},
+                {'base_link_frame': 'base_link'},
+                {'world_frame': 'odom'},
+            ],
+            remappings=[
+                ('/imu', '/imu/modified_frame_id'),
+                ('/gps/fix', '/gps/fix'),
+                ('/odometry/filtered', '/odometry/globalronan'),
+                ('/odometry/gps', '/odometry/gps'),
+            ],
+            arguments=[
+                '--ros-args', '--log-level', 'debug'
+            ]
+        )
+    ])

--- a/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/generatepath_node.py
+++ b/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/generatepath_node.py
@@ -1,0 +1,127 @@
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from nav_msgs.msg import Path
+from geometry_msgs.msg import PoseStamped
+from std_msgs.msg import Header
+
+# Function to generate path (example)
+def generate_path():
+    path = Path()
+    path.header = Header()
+    path.header.stamp = rclpy.clock.Clock().now().to_msg()
+    path.header.frame_id = "odom"  # or use the frame_id of your robot's frame
+
+    # Example of path points (x, y, theta)
+    points = []
+
+    data = """3.750639988	-2.669934191	-0.2811439543	0.9596656068
+17.99785186	-13.11623373	-0.2733425426	0.9619167606
+34.66604438	-25.24325761	-0.2519154129	0.9677492572
+36.22906321	-24.62106289	0.1915498744	0.981482881
+36.27611279	-24.59982545	0.1954977402	0.9807041519
+36.48717338	-24.50142664	0.1976271115	0.9802772693
+36.48335503	-24.50254397	0.1976087201	0.9802809769
+36.58527829	-24.45302428	0.1951213411	0.9807791098
+36.58525106	-24.45279262	0.1951696016	0.9807695074
+36.65538068	-24.18664975	0.2758829184	0.9611912481
+36.65502106	-24.18696322	0.2756984556	0.9612441738
+36.91886365	-23.98602569	0.3104214262	0.9505990417
+36.92312127	-23.98265078	0.3080542017	0.951368808
+36.95680125	-23.9531092	0.3122036881	0.9500151879
+36.93830269	-23.65695173	0.4206320683	0.9072313173
+37.08168004	-23.45187279	0.445471129	0.8952963047
+37.10713512	-23.41271161	0.4547714907	0.8906081581
+37.16100096	-23.32711556	0.4665343475	0.8845030823
+37.16437613	-23.32208727	0.4638087721	0.8859353379
+37.00446013	-22.88155675	0.5957180576	0.8031936229
+37.01397338	-22.83527861	0.5998828836	0.8000878239
+37.02855803	-22.75715828	0.6200754343	0.7845421951
+37.03178071	-22.74624755	0.6157779589	0.7879197328
+37.03786018	-22.70239902	0.6210852983	0.7837429759
+37.06272176	-22.49936178	0.6348331767	0.7726492334
+36.76685239	-22.42740386	0.7270661205	0.6865674449
+36.76073157	-22.38447022	0.7345373486	0.67856826
+36.7281743	-22.18596387	0.7518418388	0.6593434989
+36.70823228	-22.08229612	0.7608851523	0.6488865732
+36.29907391	-21.86874037	0.8539130051	0.5204157758
+36.29500476	-21.859645	0.8516575161	0.5240987267
+36.17679579	-21.65565995	0.8503182924	0.5262687541
+36.33643855	-21.939819	0.8536493699	0.5208481095
+36.29974159	-21.87732957	0.8617876928	0.5072691323
+36.29787051	-21.87293415	0.8605115045	0.5094310068
+35.84033808	-21.60863034	0.912931647	0.4081124942
+35.74956784	-21.51232809	0.9180229468	0.3965272615
+35.71570485	-21.47720692	0.918417692	0.3956121117
+35.00926617	-20.93114908	0.9347348498	0.3553459732
+34.94555596	-20.87346043	0.9332810373	0.3591469135
+34.93807017	-20.86711372	0.9333465798	0.3589765479
+34.84455309	-20.78280167	0.9323843671	0.3614683831
+34.8463514	-20.78495703	0.9322184272	0.3618961232
+34.81203783	-20.75498571	0.932542162	0.3610610974
+34.74716504	-20.6986546	0.9340539352	0.357131973
+34.7368437	-20.68940678	0.9335781255	0.3583739438
+34.70106808	-20.65905346	0.9344170299	0.356180873
+34.63458356	-20.6029175	0.9376979515	0.3474515098
+34.62310263	-20.59243739	0.9370210706	0.3492728349
+7.142827974	0.6034816286	0.9432324571	0.3321333043"""
+
+    for line in data.strip().split('\n'):
+        if line and not line.isspace():
+            x, y, qz, qw = map(float, line.split())
+            # Convert quaternion z,w components to yaw angle
+            points.append((x, y, qz, qw))
+
+    # Populate the Path message with PoseStamped
+    for point in points:
+        pose_stamped = PoseStamped()
+        pose_stamped.header = path.header  # Same header for all poses
+        pose_stamped.pose.position.x = point[0]
+        pose_stamped.pose.position.y = point[1]
+        pose_stamped.pose.position.z = 0.0  # Assuming 2D path, z=0
+
+        # Convert theta to quaternion for orientation
+        pose_stamped.pose.orientation.x = 0.0
+        pose_stamped.pose.orientation.y = 0.0
+        pose_stamped.pose.orientation.z = point[2]
+        pose_stamped.pose.orientation.w = point[3]
+
+        path.poses.append(pose_stamped)
+
+    return path
+
+
+class GeneratePath(Node):
+    def __init__(self):
+        super().__init__('generate_path_node')
+        
+        # Publisher for the corrected odom topic
+        self.publisher = self.create_publisher(
+            Path,
+            '/path',
+            10)
+        self.get_logger().info("Generate Path Node has started.")
+        self.timer = self.create_timer(1.0, self.timer_callback)
+        
+    def timer_callback(self):
+        path = generate_path()
+        self.publisher.publish(path)
+        
+def main(args=None):
+    rclpy.init(args=args)
+    node = GeneratePath()
+    
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    
+    # Shutdown the node
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()
+
+
+

--- a/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/mqtt_client_node.py
+++ b/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/mqtt_client_node.py
@@ -53,7 +53,7 @@ class Ros2MqttClient(Node):
         super().__init__('ros2_mqtt_client')
         self.sub_gps = self.create_subscription(
             NavSatFix,
-            '/gps/fix',
+            '/gps/filtered',
             self.gps_listener_callback,
             10
         )

--- a/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/odom_yaw_flip_node.py
+++ b/raspberryPI3/ros2_ws/src/mqtt_client/mqtt_client/odom_yaw_flip_node.py
@@ -1,0 +1,97 @@
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Quaternion
+import math
+
+def euler_from_quaternion(x, y, z, w):
+    """
+    Convert a quaternion into Euler angles (roll, pitch, yaw)
+    """
+    t0 = +2.0 * (w * x + y * z)
+    t1 = +1.0 - 2.0 * (x * x + y * y)
+    roll = math.atan2(t0, t1)
+    
+    t2 = +2.0 * (w * y - z * x)
+    t2 = +1.0 if t2 > +1.0 else t2
+    t2 = -1.0 if t2 < -1.0 else t2
+    pitch = math.asin(t2)
+    
+    t3 = +2.0 * (w * z + x * y)
+    t4 = +1.0 - 2.0 * (y * y + z * z)
+    yaw = math.atan2(t3, t4)
+    
+    return roll, pitch, yaw
+
+def quaternion_from_euler(roll, pitch, yaw):
+    """
+    Convert Euler angles (roll, pitch, yaw) into a quaternion
+    """
+    qx = math.sin(roll/2) * math.cos(pitch/2) * math.cos(yaw/2) - math.cos(roll/2) * math.sin(pitch/2) * math.sin(yaw/2)
+    qy = math.cos(roll/2) * math.sin(pitch/2) * math.cos(yaw/2) + math.sin(roll/2) * math.cos(pitch/2) * math.sin(yaw/2)
+    qz = math.cos(roll/2) * math.cos(pitch/2) * math.sin(yaw/2) - math.sin(roll/2) * math.sin(pitch/2) * math.cos(yaw/2)
+    qw = math.cos(roll/2) * math.cos(pitch/2) * math.cos(yaw/2) + math.sin(roll/2) * math.sin(pitch/2) * math.sin(yaw/2)
+    
+    return [qx, qy, qz, qw]
+
+class OdomCorrectionNode(Node):
+    def __init__(self):
+        super().__init__('odom_correction_node')
+        
+        # Subscriber to the original odom topic
+        self.subscription = self.create_subscription(
+            Odometry,
+            'odom/encoder',
+            self.odom_callback,
+            10)
+        
+        # Publisher for the corrected odom topic
+        self.publisher = self.create_publisher(
+            Odometry,
+            'odom/encoder_flip',
+            10)
+        
+        self.get_logger().info("Odom Correction Node has started.")
+
+    def odom_callback(self, msg):
+        # Extract the orientation quaternion from the odom message
+        orientation_q = msg.pose.pose.orientation
+        quaternion = [orientation_q.x, orientation_q.y, orientation_q.z, orientation_q.w]
+        
+        # Convert quaternion to Euler angles
+        roll, pitch, yaw = euler_from_quaternion(*quaternion)
+        
+        # Flip the yaw to correct the orientation
+        corrected_yaw = -yaw
+        
+        # Convert corrected Euler angles back to quaternion
+        corrected_quaternion = quaternion_from_euler(roll, pitch, corrected_yaw)
+        
+        # Invert the Y position as well
+        msg.pose.pose.position.y = -msg.pose.pose.position.y
+        
+        # Update the odometry message with the corrected orientation
+        msg.pose.pose.orientation.x = corrected_quaternion[0]
+        msg.pose.pose.orientation.y = corrected_quaternion[1]
+        msg.pose.pose.orientation.z = corrected_quaternion[2]
+        msg.pose.pose.orientation.w = corrected_quaternion[3]
+        
+        # Publish the corrected odometry
+        self.publisher.publish(msg)
+        self.get_logger().info("Published corrected odometry.")
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = OdomCorrectionNode()
+    
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    
+    # Shutdown the node
+    node.destroy_node()
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/raspberryPI3/ros2_ws/src/mqtt_client/setup.py
+++ b/raspberryPI3/ros2_ws/src/mqtt_client/setup.py
@@ -21,6 +21,8 @@ setup(
     entry_points={
         'console_scripts': [
             'mqtt_client = mqtt_client.mqtt_client_node:main',
+            'odom_yaw_flip = mqtt_client.odom_yaw_flip_node:main',
+            'generatepath = mqtt_client.generatepath_node:main',
         ],
     },
 )


### PR DESCRIPTION
# Description

It uses `robot_localization` packages.

# READ ME

Yes I created two nodes in `mqtt_client` packages. They should not be there, I can move them if needed but I wanted to save time. These two nodes are more like tools / hacks.

# Main issues to have a working solution:

- Sensor message with no covariance
- Sensor message with no frame_id
- TF should be published between base_link, map and odom (at least for RViz2) (`ros2 run tf2_ros static_transform_publisher 0 0 0 0 0 0 base_link odom`...)
-  Input of `navsat_transform_node` must be correctly remapped. (The official documentation is not up to date)
- EKF configs must use the right frames.
- local localization is differential in our case
- setting up covariance of sensors for EKF (we trust more x,y for the gps, but more xpoint,ypoint, yaw for local)
- GPS messages frequency: set up a long queue (50?), sensor_timeout higher = less localization published. 

# To do

- We need to investigate the fix of the GPS to avoid the offset like in the following examples.

I manually checked and in average, the orientation is quite accurate (except when the offset happens) and for the position, it's around 30cm precision on average.

# Examples on the bag of 2025_01_07-10_31_08 (7st Jan 2025, 10h31mn08s)
![Screenshot from 2025-01-16 18-41-27](https://github.com/user-attachments/assets/a60ae5f0-215c-4343-b6cf-dc11ebeb87ee)
![Screenshot from 2025-01-16 18-19-00](https://github.com/user-attachments/assets/f648e4d9-a170-4712-80da-f5375a7a6e37)
